### PR TITLE
# This creates the license section with a badge.

### DIFF
--- a/assets/generateMarkdown.js
+++ b/assets/generateMarkdown.js
@@ -1,7 +1,8 @@
 // a function that returns a license badge based on which license is passed in
 const renderLicenseBadge = (license) => {
   if (license !== "None") {
-    return `![GitHub license](https://img.shields.io/badge/license-${license}-blue.svg) | [![License: ${license}](https://img.shields.io/badge/License-${license}-yellow.svg)](https://opensource.org/licenses/${license})`;
+    return `This project is licensed under the ${license} license.
+    ![GitHub license](https://img.shields.io/badge/license-${license}-blue.svg) | [![License: ${license}](https://img.shields.io/badge/License-${license}-yellow.svg)](https://opensource.org/licenses/${license})`;
   }
   return '';
 };

--- a/assets/generateMarkdown.js
+++ b/assets/generateMarkdown.js
@@ -1,7 +1,7 @@
 // a function that returns a license badge based on which license is passed in
 const renderLicenseBadge = (license) => {
   if (license !== "None") {
-    return `![GitHub license](https://img.shields.io/badge/license-${license}-blue.svg)`;
+    return `![GitHub license](https://img.shields.io/badge/license-${license}-blue.svg) | [![License: ${license}](https://img.shields.io/badge/License-${license}-yellow.svg)](https://opensource.org/licenses/${license})`;
   }
   return '';
 };
@@ -18,6 +18,9 @@ function renderLicenseSection(license) {}
 function generateMarkdown(data) {
 
   return `# ${data.title}
+
+## License
+${renderLicenseBadge(data.license)}
 
 ## Description
 > ${data.description}
@@ -36,11 +39,6 @@ ${data.installation}
 
 ## Credits
 ${data.credits}
-
----
-
-## License
-${renderLicenseBadge(data.license)}
 
 ---
 

--- a/assets/generateMarkdown.js
+++ b/assets/generateMarkdown.js
@@ -1,5 +1,10 @@
 // a function that returns a license badge based on which license is passed in
-
+const renderLicenseBadge = (license) => {
+  if (license !== "None") {
+    return `![GitHub license](https://img.shields.io/badge/license-${license}-blue.svg)`;
+  }
+  return '';
+};
 
 // TODO: Create a function that returns the license link
 // If there is no license, return an empty string
@@ -17,20 +22,37 @@ function generateMarkdown(data) {
 ## Description
 > ${data.description}
 
+---
+
 ## installation
 ${data.installation}
+
+---
 
 ## Usage
 > ${data.usage}
 
-## Contributing
-${data.contributing}
+---
 
 ## Credits
 ${data.credits}
 
+---
+
+## License
+${renderLicenseBadge(data.license)}
+
+---
+
 ## Features
 ${data.features}
+
+---
+
+## Contributing
+${data.contributing}
+
+---
 
 ## Test
 ${data.test}

--- a/index.js
+++ b/index.js
@@ -68,6 +68,13 @@ const questions = [
     name: "test",
     message: colors.green.bold("Please enter the test instructions for your project:"),
     validate: (value) => value ? true : colors.red.bold("Please enter a valid test instructions for your project"),
+  },
+  {
+    type: "list",
+    name: "license",
+    message: colors.green.bold("Please select the license for your project:"),
+    choices: ["MIT", "Apache", "GPL", "None"],
+    default: "MIT",
   }
 
 ];


### PR DESCRIPTION
## Description:
This pull request introduces the functionality for developers to select a license for their application from a list of options. Upon selection, the README generator will dynamically add a badge for the chosen license near the top of the README. Additionally, a notice explaining the license will populate the "License" section of README, ensuring clarity and professionalism for users.

## Changes Made:
1. Enhanced main.js and generateMarkdown.js to include:
  - A prompt allowing users to select a license from available options.
  - Logic to fetch and integrate the corresponding license badge.
  - Populated the "License" section of the README with a notice about the chosen license.