### PR TITLE
# This adds the link to the user's GitHub profile.

### DIFF
--- a/assets/generateMarkdown.js
+++ b/assets/generateMarkdown.js
@@ -1,26 +1,33 @@
 // a function that returns a license badge based on which license is passed in
 const renderLicenseBadge = (license) => {
   if (license !== "None") {
-    return `This project is licensed under the ${license} license.
-    ![GitHub license](https://img.shields.io/badge/license-${license}-blue.svg) | [![License: ${license}](https://img.shields.io/badge/License-${license}-yellow.svg)](https://opensource.org/licenses/${license})`;
+    return `${renderLicenseLink} ![GitHub license](https://img.shields.io/badge/license-${license}-blue.svg) | [![License: ${license}](https://img.shields.io/badge/License-${license}-yellow.svg)](https://opensource.org/licenses/${license})`;
   }
   return '';
 };
 
-// TODO: Create a function that returns the license link
-// If there is no license, return an empty string
-function renderLicenseLink(license) {}
+// Creating a function that returns the license link
+const renderLicenseLink = (license) => {
+  if (license !== "None") {
+    return `* [License](#license)`;
+  }
+  return '';
+};
 
-// TODO: Create a function that returns the license section of README
-// If there is no license, return an empty string
-function renderLicenseSection(license) {}
+// Creating a function that returns the license section of README
+const renderLicenseSection = (license) => {
+  if (license !== "None") {
+    return `## License
+    This project is licensed under the ${license} license.`;
+  }
+  return '';
+};
 
-// TODO: Create a function to generate markdown for README
+// Creating a function to generate markdown for README
 function generateMarkdown(data) {
 
   return `# ${data.title}
 
-## License
 ${renderLicenseBadge(data.license)}
 
 ## Description
@@ -40,6 +47,10 @@ ${data.installation}
 
 ## Credits
 ${data.credits}
+
+---
+
+${renderLicenseSection(data.license)}
 
 ---
 

--- a/assets/generateMarkdown.js
+++ b/assets/generateMarkdown.js
@@ -1,7 +1,8 @@
 // a function that returns a license badge based on which license is passed in
 const renderLicenseBadge = (license) => {
   if (license !== "None") {
-    return `${renderLicenseLink} ![GitHub license](https://img.shields.io/badge/license-${license}-blue.svg) | [![License: ${license}](https://img.shields.io/badge/License-${license}-yellow.svg)](https://opensource.org/licenses/${license})`;
+    return `![GitHub license](https://img.shields.io/badge/license-${license}-blue.svg)
+    [![License: ${license}](https://img.shields.io/badge/License-${license}-yellow.svg)](https://opensource.org/licenses/${license})`;
   }
   return '';
 };
@@ -18,7 +19,7 @@ const renderLicenseLink = (license) => {
 const renderLicenseSection = (license) => {
   if (license !== "None") {
     return `## License
-    This project is licensed under the ${license} license.`;
+This project is licensed under the ${license} license.`;
   }
   return '';
 };
@@ -29,6 +30,8 @@ function generateMarkdown(data) {
   return `# ${data.title}
 
 ${renderLicenseBadge(data.license)}
+
+${renderLicenseLink(data.license)}
 
 ## Description
 > ${data.description}
@@ -66,6 +69,11 @@ ${data.contributing}
 
 ## Test
 ${data.test}
+
+---
+
+## Questions
+Please visit my GitHub profile: [GitHub](${data.github})
 
 `;
 }

--- a/index.js
+++ b/index.js
@@ -75,6 +75,12 @@ const questions = [
     message: colors.green.bold("Please select the license for your project:"),
     choices: ["MIT", "Apache", "GPL", "None"],
     default: "MIT",
+  },
+  {
+    type: "input",
+    name: "github",
+    message: colors.green.bold("Please enter your github username:"),
+    validate: (value) => value ? true : colors.red.bold("Please enter a valid github username"),
   }
 
 ];


### PR DESCRIPTION
## Description:
>This pull request enhances the README generator to include a feature where developers can input their GitHub username. Once provided, the "Questions" section of the generated README will display the username alongside a direct link to the developer's GitHub profile, facilitating ease of contact and reference for those viewing the README.

## Changes Made:
1. Modified main.js and generateMarkdown.js to include:
  - A prompt asking users for their GitHub username.
  - Logic to populate the "Questions" section with the provided username and a hyperlink to the corresponding GitHub profile.

_Your feedback is appreciated. Kindly review the changes and let me know of any improvements or provide approval to proceed with merging._